### PR TITLE
chore: remove id from extract message options

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -39,11 +39,9 @@ export async function defineConfig(env) {
     ideExtension: {
       extractMessageOptions: [
         {
-          id: "As JSX string",
           callback: (/** @type {string} */ messageId) => `{t("${messageId}")}`,
         },
         {
-          id: "As JS string",
           callback: (/** @type {string} */ messageId) => `t("${messageId}")`,
         },
       ],


### PR DESCRIPTION
`id` is not necessary anymore: https://github.com/inlang/inlang/pull/372#pullrequestreview-1299836207