### PR TITLE
Cleaned up example page

### DIFF
--- a/resources/de.json
+++ b/resources/de.json
@@ -1,6 +1,6 @@
 {
   "hello": "hallo {{name}}, wie geht es dir?",
-  "shoeCardTitle": "Kaufe {{name}",
+  "shoeCardTitle": "Kaufe {{name}}",
   "categoryFashion": "Bekleidung",
   "shoeDescription": "Das ist nicht brillant, das ist Sparta.",
   "categoryProducts": "Produkte",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,12 +40,12 @@ export function App() {
       </div>
       <div class="card w-full bg-base-100 shadow">
         <figure>
-          <img src="https://placeimg.com/400/225/arch" alt="Shoes" />
+          <img src="https://source.unsplash.com/400x225/?shoes,commerical" alt="Shoes" />
         </figure>
         <div class="card-body">
           <h2 class="card-title">
             {t("shoeCardTitle", { name: shoeName() })}
-            <div class="badge badge-secondary">{t("new")}</div>
+            <div class="badge badge-secondary text-center h-fit">{t("new")}</div>
           </h2>
           <p>{t("shoeDescription")}</p>
           <div class="card-actions justify-end">


### PR DESCRIPTION
Hi folks,
I recently checked out the example page and saw some issues there. 
 
### Current status
<img width="515" alt="Bildschirmfoto 2023-03-01 um 10 04 08 AM" src="https://user-images.githubusercontent.com/58360188/222097049-d2c9ff2f-a7ea-4906-b6b4-e2be25ae8df6.png">

- Image is displayed with shut down msg
- In German translation there was a `}` missing
- The secondary badge is looking a bit off

### What I did
<img width="459" alt="Bildschirmfoto 2023-03-01 um 10 14 51 AM" src="https://user-images.githubusercontent.com/58360188/222097540-f929ed9b-fb42-4148-babc-10701874df38.png">

- Added a unsplash link instead. There you can also pass in a search term and it's free for commercial use. 
- Added the missing `}`
- Added some styling for the secondary badge